### PR TITLE
Se actualiza para que use el Mixin de django de ser posible

### DIFF
--- a/pagination/middleware.py
+++ b/pagination/middleware.py
@@ -1,16 +1,19 @@
-class MiddlewareMixin:
-    def __init__(self, get_response=None):
-        self.get_response = get_response
-        super().__init__()
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    class MiddlewareMixin:
+        def __init__(self, get_response=None):
+            self.get_response = get_response
+            super().__init__()
 
-    def __call__(self, request):
-        response = None
-        if hasattr(self, 'process_request'):
-            response = self.process_request(request)
-        response = response or self.get_response(request)
-        if hasattr(self, 'process_response'):
-            response = self.process_response(request, response)
-        return response
+        def __call__(self, request):
+            response = None
+            if hasattr(self, 'process_request'):
+                response = self.process_request(request)
+            response = response or self.get_response(request)
+            if hasattr(self, 'process_response'):
+                response = self.process_response(request, response)
+            return response
 
 
 def get_page(self):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.1.2'
+version = '1.1.3'
 
 LONG_DESCRIPTION = """
 How to use django-pagination-py3
@@ -116,7 +116,7 @@ setup(
     keywords='pagination,django',
     author='Agustin Mendez',
     author_email='matagus@gmail.com',
-    url='',
+    url='https://github.com/matagus/django-pagination-py3',
     license='BSD',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Para mejorar el soporte con Django 2.X y 3.X.

Ademas, porque la version subida a Pypi.org no tiene el middleware mixin 