### PR TITLE
Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.2.1"
+    rev: "v0.4.4"
     hooks:
       - id: ruff
         args: [--fix]
 
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 24.4.2
     hooks:
       - id: black
         args:
@@ -21,7 +21,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -54,7 +54,7 @@ repos:
           - "--write-changes"
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.15.2
     hooks:
     - id: pyupgrade
       args: [--py312]


### PR DESCRIPTION
> pre-commit autoupdate

[https://github.com/charliermarsh/ruff-pre-commit] updating v0.2.1 -> v0.4.4 
[https://github.com/psf/black] updating 24.1.1 -> 24.4.2 
[https://github.com/pre-commit/pre-commit-hooks] updating v4.5.0 -> v4.6.0 
[https://github.com/codespell-project/codespell] already up to date! 
[https://github.com/asottile/pyupgrade] updating v3.15.0 -> v3.15.2